### PR TITLE
fix(ci): upgrade GitHub Actions to Node 24 and tolerate sst refresh

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -20,11 +20,11 @@ jobs:
       charts: ${{ steps.set-charts.outputs.charts }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: image-changes
         if: github.event_name == 'push'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             patroni:
@@ -46,7 +46,7 @@ jobs:
 
       - id: chart-changes
         if: github.event_name == 'push'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             postgres:
@@ -115,7 +115,7 @@ jobs:
         image: ${{ fromJSON(needs.detect-changes.outputs.images) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -164,7 +164,7 @@ jobs:
         chart: ${{ fromJSON(needs.detect-changes.outputs.charts) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -36,8 +36,8 @@ jobs:
       sst: ${{ steps.filter.outputs.sst }}
       kubernetes: ${{ steps.filter.outputs.kubernetes }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -66,13 +66,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -81,12 +81,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      # TODO: remove continue-on-error after sst fixes refresh exit code bug
+      # https://github.com/anomalyco/sst/issues/6713
       - name: Refresh sst state
+        continue-on-error: true
         run: pnpm sst refresh --stage $SST_STAGE
 
       - name: Deploy SST

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install --frozen-lockfile --filter web --filter svelte
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-west-1


### PR DESCRIPTION
## Summary
- Upgrades all GitHub Actions to latest major versions with Node 24 support
- Adds `|| true` to `sst refresh` step so it doesn't block deploys when returning exit code 1 despite successful refresh

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| aws-actions/configure-aws-credentials | v4 | v6 |
| pnpm/action-setup | v4 | v5 |
| dorny/paths-filter | v3 | v4 |

## Test plan
- [ ] Deploy infra workflow passes on main
- [ ] Node 20 deprecation warnings are gone
- [ ] Build and publish workflow runs without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)