### PR TITLE
fix(ci): skip k8s deploy when no cluster and override vulnerable deps

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -117,7 +117,8 @@ jobs:
 
       - name: Configure kubeconfig
         run: |
-          if ! sudo tailscale status --peers | grep -q prod-cluster; then
+          PEERS=$(sudo tailscale status --peers) || { echo "tailscale status failed"; exit 1; }
+          if ! echo "$PEERS" | grep -q prod-cluster; then
             echo "No cluster found — skipping deployment"
             echo "SKIP_DEPLOY=true" >> $GITHUB_ENV
             exit 0

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -116,9 +116,16 @@ jobs:
           tags: tag:ci,tag:prod
 
       - name: Configure kubeconfig
-        run: sudo tailscale configure kubeconfig prod-cluster
+        run: |
+          if ! sudo tailscale status --peers | grep -q prod-cluster; then
+            echo "No cluster found — skipping deployment"
+            echo "SKIP_DEPLOY=true" >> $GITHUB_ENV
+            exit 0
+          fi
+          sudo tailscale configure kubeconfig prod-cluster
 
       - name: Trigger ArgoCD Sync
+        if: env.SKIP_DEPLOY != 'true'
         run: |
           sudo kubectl annotate application prod-cluster \
             argocd.argoproj.io/refresh=hard \
@@ -126,6 +133,7 @@ jobs:
             --namespace argocd
 
       - name: Wait for ArgoCD Sync
+        if: env.SKIP_DEPLOY != 'true'
         run: |
           for i in {1..60}; do
             STATUS=$(sudo kubectl get application prod-cluster -n argocd -o jsonpath='{.status.sync.status}')

--- a/package.json
+++ b/package.json
@@ -26,5 +26,12 @@
   },
   "dependencies": {
     "sst": "^4.7.4"
+  },
+  "pnpm": {
+    "//overrides": "TODO: remove once fonteditor-core, plist, and axios update their deps to non-vulnerable versions",
+    "overrides": {
+      "follow-redirects": ">=1.16.0",
+      "@xmldom/xmldom": ">=0.9.9"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sst": "^4.7.4"
   },
   "pnpm": {
-    "//overrides": "TODO: remove once fonteditor-core, plist, and axios update their deps to non-vulnerable versions",
+    "//TODO": "remove overrides once fonteditor-core, plist, and axios update their deps to non-vulnerable versions",
     "overrides": {
       "follow-redirects": ">=1.16.0",
       "@xmldom/xmldom": ">=0.9.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  follow-redirects: '>=1.16.0'
+  '@xmldom/xmldom': '>=0.9.9'
+
 importers:
 
   .:
@@ -2100,10 +2104,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
-    engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+  '@xmldom/xmldom@0.9.9':
+    resolution: {integrity: sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==}
+    engines: {node: '>=14.6'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -2842,8 +2845,8 @@ packages:
   fmix@0.1.0:
     resolution: {integrity: sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -7445,7 +7448,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xmldom/xmldom@0.8.11': {}
+  '@xmldom/xmldom@0.9.9': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -7555,7 +7558,7 @@ snapshots:
 
   axios@1.13.6:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -8260,11 +8263,11 @@ snapshots:
       imul: 1.0.1
     optional: true
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   fonteditor-core@2.6.3:
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.9.9
 
   form-data@4.0.5:
     dependencies:
@@ -9196,7 +9199,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.9.9
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Summary
- Kubernetes deploy now checks if `prod-cluster` peer exists in Tailscale before attempting kubeconfig setup. Skips ArgoCD sync gracefully when cluster is scaled to 0.
- Adds pnpm overrides to force secure versions of `follow-redirects` (>=1.16.0) and `@xmldom/xmldom` (>=0.9.9). Upstream packages (twilio, fonteditor-core, electron-forge) pin vulnerable versions with no fix available.

## Test plan
- [ ] `workflow_dispatch` deploy succeeds with no cluster running
- [ ] Dependabot security alerts for follow-redirects and @xmldom/xmldom resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)