### PR TITLE
fix(ci): skip paths-filter on workflow_dispatch

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -21,6 +21,14 @@ on:
         options:
           - production
           - pandoks
+      deploy:
+        description: 'What to deploy'
+        type: choice
+        default: all
+        options:
+          - all
+          - sst
+          - kubernetes
 
 permissions:
   id-token: write
@@ -33,11 +41,12 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      sst: ${{ steps.filter.outputs.sst }}
-      kubernetes: ${{ steps.filter.outputs.kubernetes }}
+      sst: ${{ github.event_name != 'workflow_dispatch' && steps.filter.outputs.sst || contains(fromJSON('["all","sst"]'), inputs.deploy) }}
+      kubernetes: ${{ github.event_name != 'workflow_dispatch' && steps.filter.outputs.kubernetes || contains(fromJSON('["all","kubernetes"]'), inputs.deploy) }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
+        if: github.event_name != 'workflow_dispatch'
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary
- Skips `dorny/paths-filter` on `workflow_dispatch` since there's no push event to diff against
- Defaults both `sst` and `kubernetes` outputs to `true` on manual triggers (you triggered it manually, so run everything)
- Suppresses the "'before' field is missing in event payload" warning

## Test plan
- [ ] Manual `workflow_dispatch` runs without the warning
- [ ] Push-triggered deploys still respect path filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)