### PR TITLE
fix(ci): name aggregator check jobs by workflow

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -263,6 +263,7 @@ jobs:
           helm push "${{ matrix.chart.name }}"-*.tgz "oci://ghcr.io/${OWNER,,}/charts"
 
   check:
+    name: Build and Publish
     needs:
       - build-publish-images
       - build-publish-charts

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -380,6 +380,7 @@ jobs:
         run: pnpm sst diff --stage production
 
   check:
+    name: Checks
     needs:
       - format-js
       - lint-js

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -120,6 +120,7 @@ jobs:
           category: trivy-k3s
 
   check:
+    name: Security
     needs:
       - scan-k3s-config
     if: ${{ always() && !cancelled() && github.event_name == 'pull_request' && !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -146,6 +146,7 @@ jobs:
         run: pnpm --filter @pandoks.com/valkey test
 
   check:
+    name: Tests
     needs:
       - test-web
       - test-desktop

--- a/infra/github.ts
+++ b/infra/github.ts
@@ -24,12 +24,7 @@ if (isProduction) {
     requiredStatusChecks: [
       {
         strict: false,
-        contexts: [
-          'Checks / check',
-          'Security / check',
-          'Tests / check',
-          'Build and Publish / check'
-        ]
+        contexts: ['Checks', 'Security', 'Tests', 'Build and Publish']
       }
     ],
     allowsDeletions: false,


### PR DESCRIPTION
## Summary

- Required-status checks on PRs currently show "waiting for required to be reported" even when all checks pass.
- Root cause: each workflow (`Checks`, `Security`, `Tests`, `Build and Publish`) defines a job literally named `check`. GitHub Actions publishes the check-run under the bare job name — there's no automatic `<workflow> / <job>` prefix — so all four collapse to the same context string and no branch-protection rule matches.
- Fix: set `jobs.check.name:` to the workflow's display name in each file. Each aggregator now publishes a distinct check-run (`Checks`, `Security`, `Tests`, `Build and Publish`).
- IaC: updated `infra/github.ts` so the SST-managed branch-protection rule references the new context names. The `Deploy Infrastructure` workflow auto-runs on `infra/**` changes pushed to main, so the rule update applies right after merge.

## Test plan

- [ ] After merge, `Deploy Infrastructure` runs on main and updates branch protection to the new contexts
- [ ] A fresh PR's required status checks resolve to `Checks`, `Security`, `Tests`, `Build and Publish` (no more "waiting")
- [ ] PR #58 (`k3s-security`) rebased / merged-from-main and goes mergeable

Generated with Claude Code