### PR TITLE
update(infra): builder SFN input shape

### DIFF
--- a/infra/builder/step.ts
+++ b/infra/builder/step.ts
@@ -179,9 +179,7 @@ export function builderStateMachineDefinition({
         States: {
           ResolveInputs: {
             Type: 'Choice',
-            Choices: [
-              { Variable: '$.id', IsPresent: true, Next: 'ResolveInputsWithId' }
-            ],
+            Choices: [{ Variable: '$.id', IsPresent: true, Next: 'ResolveInputsWithId' }],
             Default: 'ResolveInputsWithExecutionId'
           },
           ResolveInputsWithId: {

--- a/infra/builder/step.ts
+++ b/infra/builder/step.ts
@@ -27,8 +27,8 @@ function launchInstance(architecture: 'x86' | 'arm64', market: 'spot' | 'on-dema
         {
           ResourceType: 'instance',
           Tags: [
-            { Key: 'BuildId', 'Value.$': '$.buildId' },
-            { Key: 'RepoRef', 'Value.$': '$.repoRef' }
+            { Key: 'Id', 'Value.$': '$.id' },
+            { Key: 'Ref', 'Value.$': '$.ref' }
           ]
         }
       ]
@@ -175,15 +175,37 @@ export function builderStateMachineDefinition({
       return JSON.stringify({
         Comment:
           'Ephemeral EC2 builder — launch (arch-routed), run script via SSM, always terminate',
-        StartAt: 'ResolveLaunchTemplates',
+        StartAt: 'ResolveInputs',
         States: {
-          ResolveLaunchTemplates: {
+          ResolveInputs: {
+            Type: 'Choice',
+            Choices: [
+              { Variable: '$.id', IsPresent: true, Next: 'ResolveInputsWithId' }
+            ],
+            Default: 'ResolveInputsWithExecutionId'
+          },
+          ResolveInputsWithId: {
             Type: 'Pass',
-            Result: {
-              launchTemplateIdX86,
-              launchTemplateIdArm64
+            Parameters: {
+              'id.$': '$.id',
+              'ref.$': '$.ref',
+              'instanceType.$': '$.instanceType',
+              'marketType.$': '$.marketType',
+              'command.$': '$.command',
+              templates: { launchTemplateIdX86, launchTemplateIdArm64 }
             },
-            ResultPath: '$.templates',
+            Next: 'ChooseArchitecture'
+          },
+          ResolveInputsWithExecutionId: {
+            Type: 'Pass',
+            Parameters: {
+              'id.$': '$$.Execution.Name',
+              'ref.$': '$.ref',
+              'instanceType.$': '$.instanceType',
+              'marketType.$': '$.marketType',
+              'command.$': '$.command',
+              templates: { launchTemplateIdX86, launchTemplateIdArm64 }
+            },
             Next: 'ChooseArchitecture'
           },
           ...instanceTypesGate,
@@ -200,7 +222,7 @@ export function builderStateMachineDefinition({
               DocumentName: 'AWS-RunShellScript',
               TimeoutSeconds: 60,
               Parameters: {
-                'commands.$': `States.Array(States.Format('bash -c \\'${bashScript}\\'', $.buildId, $.repoRef, $.command))`,
+                'commands.$': `States.Array(States.Format('bash -c \\'${bashScript}\\'', $.id, $.ref, $.command))`,
                 executionTimeout: ['86400'] // 24 hours
               },
               CloudWatchOutputConfig: { CloudWatchOutputEnabled: true }


### PR DESCRIPTION
## Summary

- Rename SFN input field `repoRef` → `ref` (and `RepoRef` EC2 tag → `Ref`). `--branch` accepts tags as well as branches, so `ref` is more accurate and matches the GitHub Actions / GitLab convention.
- Rename `buildId` → `id` (and `BuildId` EC2 tag → `Id`).
- Make `id` optional in the input. When omitted, `$.id` is seeded from `$$.Execution.Name` (caller's `StartExecution.name`, or an SFN-generated UUID).
- Merge the seeding into the existing first Pass state via a Choice on `IsPresent`; no extra hops.

New input shape:

```json
{
  "instanceType": "c7g.large",
  "marketType": "spot",
  "ref": "main",
  "command": "make ami",
  "id": "optional-build-name"
}
```

The bash script env var stays `BUILD_ID` so user-supplied build commands keep working.

## Test plan

- [ ] `pnpm check:infra` passes
- [ ] `sst diff --stage pandoks` shows only the state machine `definition` changing
- [ ] Start an execution without `id` → EC2 instance tagged `Id=<execution-name>`, `Ref=<branch>`
- [ ] Start an execution with `id: "foo"` → EC2 instance tagged `Id=foo`
- [ ] Start an execution with `StartExecution(name: "bar")` and no `id` in input → tagged `Id=bar`

Generated with Claude Code