### PR TITLE
update(infra): builder SFN storage size input

### DIFF
--- a/infra/builder/step.ts
+++ b/infra/builder/step.ts
@@ -48,6 +48,23 @@ function launchInstance(architecture: 'x86' | 'arm64', market: 'spot' | 'on-dema
   };
 }
 
+const storageSizeGate = {
+  ValidateStorageSize: {
+    Type: 'Choice',
+    Choices: [
+      {
+        And: [
+          { Variable: '$.storageSizeGib', IsNumeric: true },
+          { Variable: '$.storageSizeGib', NumericGreaterThanEquals: 8 },
+          { Variable: '$.storageSizeGib', NumericLessThanEquals: 16384 }
+        ],
+        Next: 'ChooseArchitecture'
+      }
+    ],
+    Default: 'FailInvalidStorageSize'
+  }
+};
+
 const instanceTypesGate = {
   ChooseArchitecture: {
     Type: 'Choice',
@@ -273,6 +290,11 @@ export function builderStateMachineDefinition({
             Type: 'Fail',
             Cause: 'instanceType is not in the supported list',
             Error: 'InvalidInstanceType'
+          },
+          FailInvalidStorageSize: {
+            Type: 'Fail',
+            Cause: 'storageSizeGib must be a number between 8 and 16384 (gp3 max)',
+            Error: 'InvalidStorageSize'
           },
           FailBuild: {
             Type: 'Fail',

--- a/infra/builder/step.ts
+++ b/infra/builder/step.ts
@@ -15,6 +15,15 @@ function launchInstance(architecture: 'x86' | 'arm64', market: 'spot' | 'on-dema
       MinCount: 1,
       MaxCount: 1,
       'InstanceType.$': '$.instanceType',
+      BlockDeviceMappings: [
+        {
+          DeviceName: '/dev/sda1',
+          Ebs: {
+            'VolumeSize.$': '$.storageSizeGib',
+            DeleteOnTermination: true
+          }
+        }
+      ],
       ...(market === 'spot'
         ? {
             InstanceMarketOptions: {

--- a/infra/builder/step.ts
+++ b/infra/builder/step.ts
@@ -51,6 +51,12 @@ function launchInstance(architecture: 'x86' | 'arm64', market: 'spot' | 'on-dema
 }
 
 const storageSizeGate = {
+  NormalizeStorageSize: {
+    Type: 'Pass',
+    Parameters: { 'storageSizeGibStr.$': "States.Format('{}', $.storageSizeGib)" },
+    ResultPath: '$.normalized',
+    Next: 'ValidateStorageSize'
+  },
   ValidateStorageSize: {
     Type: 'Choice',
     Choices: [
@@ -58,7 +64,8 @@ const storageSizeGate = {
         And: [
           { Variable: '$.storageSizeGib', IsNumeric: true },
           { Variable: '$.storageSizeGib', NumericGreaterThanEquals: 8 },
-          { Variable: '$.storageSizeGib', NumericLessThanEquals: 16384 }
+          { Variable: '$.storageSizeGib', NumericLessThanEquals: 16384 },
+          { Not: { Variable: '$.normalized.storageSizeGibStr', StringMatches: '*.*' } }
         ],
         Next: 'ChooseArchitecture'
       }
@@ -174,7 +181,7 @@ const fails = {
   },
   FailInvalidStorageSize: {
     Type: 'Fail',
-    Cause: 'storageSizeGib must be a number between 8 and 16384 (gp3 max)',
+    Cause: 'storageSizeGib must be an integer between 8 and 16384 (gp3 max)',
     Error: 'InvalidStorageSize'
   },
   FailBuild: {
@@ -251,7 +258,7 @@ export function builderStateMachineDefinition({
             Type: 'Pass',
             Result: { launchTemplateIdX86, launchTemplateIdArm64 },
             ResultPath: '$.templates',
-            Next: 'ValidateStorageSize'
+            Next: 'NormalizeStorageSize'
           },
           ...storageSizeGate,
           ...instanceTypesGate,

--- a/infra/builder/step.ts
+++ b/infra/builder/step.ts
@@ -236,18 +236,24 @@ export function builderStateMachineDefinition({
             OutputPath: '$.resolved',
             Next: 'ResolveId'
           },
-          ResolveInputsWithExecutionId: {
-            Type: 'Pass',
-            Parameters: {
-              'id.$': '$$.Execution.Name',
-              'ref.$': '$.ref',
-              'instanceType.$': '$.instanceType',
-              'marketType.$': '$.marketType',
-              'command.$': '$.command',
-              templates: { launchTemplateIdX86, launchTemplateIdArm64 }
-            },
-            Next: 'ChooseArchitecture'
+          ResolveId: {
+            Type: 'Choice',
+            Choices: [{ Variable: '$.id', IsPresent: true, Next: 'AttachTemplates' }],
+            Default: 'FallbackId'
           },
+          FallbackId: {
+            Type: 'Pass',
+            InputPath: '$$.Execution.Name',
+            ResultPath: '$.id',
+            Next: 'AttachTemplates'
+          },
+          AttachTemplates: {
+            Type: 'Pass',
+            Result: { launchTemplateIdX86, launchTemplateIdArm64 },
+            ResultPath: '$.templates',
+            Next: 'ValidateStorageSize'
+          },
+          ...storageSizeGate,
           ...instanceTypesGate,
           LaunchSpotX86: launchInstance('x86', 'spot'),
           LaunchOnDemandX86: launchInstance('x86', 'on-demand'),

--- a/infra/builder/step.ts
+++ b/infra/builder/step.ts
@@ -1,6 +1,8 @@
 import { githubOrg, githubRepoName } from '../github';
 import { ARM_INSTANCE_TYPES, X86_INSTANCE_TYPES } from './types';
 
+const INPUT_DEFAULTS = { storageSizeGib: 8 };
+
 function launchInstance(architecture: 'x86' | 'arm64', market: 'spot' | 'on-demand') {
   return {
     Type: 'Task',
@@ -224,24 +226,15 @@ export function builderStateMachineDefinition({
       return JSON.stringify({
         Comment:
           'Ephemeral EC2 builder — launch (arch-routed), run script via SSM, always terminate',
-        StartAt: 'ResolveInputs',
+        StartAt: 'ApplyDefaults',
         States: {
-          ResolveInputs: {
-            Type: 'Choice',
-            Choices: [{ Variable: '$.id', IsPresent: true, Next: 'ResolveInputsWithId' }],
-            Default: 'ResolveInputsWithExecutionId'
-          },
-          ResolveInputsWithId: {
+          ApplyDefaults: {
             Type: 'Pass',
             Parameters: {
-              'id.$': '$.id',
-              'ref.$': '$.ref',
-              'instanceType.$': '$.instanceType',
-              'marketType.$': '$.marketType',
-              'command.$': '$.command',
-              templates: { launchTemplateIdX86, launchTemplateIdArm64 }
+              'resolved.$': `States.JsonMerge(States.StringToJson('${JSON.stringify(INPUT_DEFAULTS)}'), $$.Execution.Input, false)`
             },
-            Next: 'ChooseArchitecture'
+            OutputPath: '$.resolved',
+            Next: 'ResolveId'
           },
           ResolveInputsWithExecutionId: {
             Type: 'Pass',

--- a/infra/builder/step.ts
+++ b/infra/builder/step.ts
@@ -159,6 +159,29 @@ const waitForBuild = {
   }
 };
 
+const fails = {
+  FailNoInstance: {
+    Type: 'Fail',
+    Cause: 'RunInstances failed; nothing to terminate',
+    Error: 'LaunchFailed'
+  },
+  FailInvalidInstanceType: {
+    Type: 'Fail',
+    Cause: 'instanceType is not in the supported list',
+    Error: 'InvalidInstanceType'
+  },
+  FailInvalidStorageSize: {
+    Type: 'Fail',
+    Cause: 'storageSizeGib must be a number between 8 and 16384 (gp3 max)',
+    Error: 'InvalidStorageSize'
+  },
+  FailBuild: {
+    Type: 'Fail',
+    Cause: 'Remote build command failed, was cancelled, or timed out',
+    Error: 'BuildFailed'
+  }
+};
+
 export function builderStateMachineDefinition({
   launchTemplateIdX86,
   launchTemplateIdArm64,
@@ -281,26 +304,7 @@ export function builderStateMachineDefinition({
               { ErrorEquals: ['States.ALL'], ResultPath: '$.terminationError', Next: 'FailBuild' }
             ]
           },
-          FailNoInstance: {
-            Type: 'Fail',
-            Cause: 'RunInstances failed; nothing to terminate',
-            Error: 'LaunchFailed'
-          },
-          FailInvalidInstanceType: {
-            Type: 'Fail',
-            Cause: 'instanceType is not in the supported list',
-            Error: 'InvalidInstanceType'
-          },
-          FailInvalidStorageSize: {
-            Type: 'Fail',
-            Cause: 'storageSizeGib must be a number between 8 and 16384 (gp3 max)',
-            Error: 'InvalidStorageSize'
-          },
-          FailBuild: {
-            Type: 'Fail',
-            Cause: 'Remote build command failed, was cancelled, or timed out',
-            Error: 'BuildFailed'
-          },
+          ...fails,
           Done: { Type: 'Succeed' }
         }
       });


### PR DESCRIPTION
## Summary
- Add `storageSizeGib` optional input to builder SFN (default 8 GiB, range [8, 16384] for gp3 max)
- Inject `BlockDeviceMappings` into RunInstances to override the AMI's baked root volume
- Refactor input resolution to `States.JsonMerge`-based pattern — N optional fields now cost O(1) states instead of O(2^N)
- Add `ValidateStorageSize` Choice gate + `FailInvalidStorageSize` terminal state, symmetric with the existing instance-type validation

## Test plan
- [ ] Deploy to dev stage, invoke SFN with no `storageSizeGib` → confirm 8 GiB root volume
- [ ] Invoke with `storageSizeGib: 64` → confirm 64 GiB root volume
- [ ] Invoke with `storageSizeGib: 4` → confirm \`FailInvalidStorageSize\`
- [ ] Invoke with `storageSizeGib: "abc"` → confirm \`FailInvalidStorageSize\` (IsNumeric guard)
- [ ] Confirm existing builds without the field still succeed (backwards compat)

Generated with Claude Code