### PR TITLE
fix(web): switch from inline critical fonts to full woff2

### DIFF
--- a/apps/web/src/lib/server/critical-fonts.test.ts
+++ b/apps/web/src/lib/server/critical-fonts.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { parse, type HTMLElement } from 'node-html-parser';
-import { collectFontData, fontFromHtmlElement } from './critical-fonts';
+import { collectFontData, fontFromHtmlElement, injectCriticalFonts } from './critical-fonts';
+import { FONTS, type FontKey } from '$lib/fonts';
 
 const element = (html: string): HTMLElement =>
   parse(`<body>${html}</body>`).querySelector('body')!.firstChild as HTMLElement;
 
 const wrap = (body: string) => `<html><body>${body}</body></html>`;
+
+const page = (body: string) => `<html><head></head><body>${body}</body></html>`;
 
 describe('fontFromHtmlElement', () => {
   it('defaults to inter when no font class is present in the ancestor chain', () => {
@@ -208,5 +211,45 @@ describe('collectFontData', () => {
   it('deduplicates repeated characters within a bucket', () => {
     const { inter } = collectFontData(wrap('<p>aaa</p><span>aab</span>'));
     expect([...inter.chars].sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('injectCriticalFonts inline → woff2 switch contract', () => {
+  const blogish = page(
+    '<h1 class="font-black">Hello</h1>' +
+      '<div class="font-garamond"><p>The quick brown fox</p>' +
+      '<em class="italic">jumps over</em></div>'
+  );
+
+  it('tags each inline face with a valued data-critical-font matching its FONTS key', async () => {
+    const dom = parse(await injectCriticalFonts(blogish));
+    for (const style of dom.querySelectorAll('style[data-critical-font]')) {
+      const key = style.getAttribute('data-critical-font');
+      expect(Object.keys(FONTS)).toContain(key);
+    }
+  });
+
+  it('keeps the :root variable rule in a tag with no data-critical-font attribute', () => {
+    return injectCriticalFonts(blogish).then((html) => {
+      const dom = parse(html);
+      const rootTags = dom.querySelectorAll('style').filter((s) => s.innerHTML.includes(':root'));
+      expect(rootTags).toHaveLength(1);
+      const [rootTag] = rootTags;
+      expect(rootTag?.getAttribute('data-critical-font')).toBeUndefined();
+    });
+  });
+
+  it('every injected inline face is removable by the client per-key selector', async () => {
+    const dom = parse(await injectCriticalFonts(blogish));
+    expect(dom.querySelectorAll('style[data-critical-font]').length).toBeGreaterThan(0);
+
+    for (const key of Object.keys(FONTS) as FontKey[]) {
+      dom.querySelector(`style[data-critical-font="${key}"]`)?.remove();
+    }
+
+    const survivors = dom
+      .querySelectorAll('style')
+      .filter((s) => /font-family:'[^']*-Inline'/.test(s.innerHTML));
+    expect(survivors.map((s) => s.innerHTML)).toEqual([]);
   });
 });

--- a/apps/web/src/lib/server/critical-fonts.ts
+++ b/apps/web/src/lib/server/critical-fonts.ts
@@ -82,7 +82,7 @@ export async function injectCriticalFonts(html: string): Promise<string> {
   const usedKeys = (Object.keys(FONTS) as FontKey[]).filter((key) => data[key].chars.size > 0);
   if (!usedKeys.length) return html;
 
-  const fontFaces = await Promise.all(
+  const styleTags = await Promise.all(
     usedKeys.map(async (key) => {
       const { file, family, style } = FONTS[key];
       const { chars, weights } = data[key];
@@ -96,13 +96,14 @@ export async function injectCriticalFonts(html: string): Promise<string> {
       });
       const b64 = Buffer.from(subset).toString('base64');
 
-      return (
+      const face =
         `@font-face{font-family:'${family}-Inline';` +
         `src:url(data:font/woff2;base64,${b64}) format('woff2');` +
         `font-weight:${isFixedWeight ? min : `${min} ${max}`};` +
         `font-style:${style};font-display:block;` +
-        `unicode-range:${unicodeRange(chars)}}`
-      );
+        `unicode-range:${unicodeRange(chars)}}`;
+
+      return `<style data-critical-font="${key}">${face}</style>`;
     })
   );
 
@@ -115,7 +116,6 @@ export async function injectCriticalFonts(html: string): Promise<string> {
     })
     .join(';');
 
-  const styleTag =
-    `<style data-critical-font>` + fontFaces.join('') + `:root{${rootRule}}` + `</style>`;
-  return html.replace(/<\/head>/i, `${styleTag}</head>`);
+  const rootTag = `<style>:root{${rootRule}}</style>`;
+  return html.replace(/<\/head>/i, `${styleTags.join('')}${rootTag}</head>`);
 }

--- a/apps/web/src/routes/blog/[title]/+page.svelte
+++ b/apps/web/src/routes/blog/[title]/+page.svelte
@@ -58,7 +58,7 @@
         target="_blank"
         rel="external noopener noreferrer"
         class={`text-neutral-500 hover:cursor-pointer hover:underline
-              ${annotations.bold ? 'font-medium' : ''}
+              ${annotations.bold ? 'font-bold' : ''}
               ${annotations.italic ? 'italic' : ''}
               ${annotations.strikethrough ? 'line-through' : ''}
               ${annotations.underline ? 'underline' : ''}`}
@@ -67,7 +67,7 @@
       </a>
     {:else}
       <span
-        class={`${annotations.bold ? 'font-medium' : ''}
+        class={`${annotations.bold ? 'font-bold' : ''}
               ${annotations.italic ? 'italic' : ''}
               ${annotations.strikethrough ? 'line-through' : ''}
               ${annotations.underline ? 'underline' : ''}`}


### PR DESCRIPTION
## Problem

On blog pages (e.g. `/blog/the-human-experience`), bold fonts didn't load — the page stayed on the tiny inline font subset and never adopted the downloaded `.woff2` files.

**Root cause:** the inline→woff2 switch was a no-op due to a selector/attribute mismatch between the server and client.

| | Server emitted | Client queried |
|---|---|---|
| `injectCriticalFonts` (`critical-fonts.ts:119`) | `<style data-critical-font>` — **valueless**, one tag for all faces | — |
| removal (`+layout.svelte:16`) | — | `style[data-critical-font="${key}"]` — **valued**, per key |

`style[data-critical-font="inter"]` never matches a valueless `data-critical-font` attribute, so `?.remove()` short-circuits to a silent no-op. The inline `*-Inline` faces survive on every page, so the CSS stack `'Inter-Inline', 'Inter', …` keeps resolving to the inline subset first and the full woff2 is only ever used to patch missing glyphs. Bold weights the subset lacks (e.g. EB Garamond 700) never render correctly.

## Fix

- **`critical-fonts.ts`** — emit one `<style data-critical-font="${key}">` per font key so the existing per-key removal loop matches. Keep the shared `:root` font-variable rule in its own attribute-less `<style>` so removing a font's tag doesn't strip the CSS variables.
- **`+layout.svelte`** — unchanged; its per-key loop was already correct.
- **`blog/[title]/+page.svelte`** — separate bug: Notion **bold** annotations emitted `font-medium` (500) instead of `font-bold` (700). Corrected both spots (link + span).

## Verification

Headless Chromium against the real `/blog/the-human-experience` route (`vite preview`), waiting for `document.fonts.status === 'loaded'`:

| Check | main (broken) | this PR |
|---|---|---|
| Surviving inline `<style>` | **1** | **0** |
| `fonts.check("700 'Inter'")` | true | true |
| `fonts.check("700 'EB Garamond'")` | **false** | **true** |
| Switch happened | **NO** | **YES** |

Added 3 switch-contract tests to `critical-fonts.test.ts` (32 tests total, was 29) that run the real injector output through the client's exact removal selector — fails on the old behavior, passes here. `svelte-check`, `eslint`, `prettier`, and `vite build` all clean.

> Opening this PR to trigger a Cloudflare Pages **preview deployment** (paths touch `apps/web/**`) — the preview URL should appear as a PR comment so the font switch can be eyeballed on the deployed page.

Generated with Claude Code