### PR TITLE
fix(deps): bump jq/apache2-utils in argocd Dockerfile for HIGH CVEs

### DIFF
--- a/.claude/rules/gotchas/setup.md
+++ b/.claude/rules/gotchas/setup.md
@@ -151,7 +151,7 @@ the original problem.
     (`renovate.json:28`), so its PR always needs a manual SHA edit.
   - A minor bump also changes the Go toolchain kubectl is built on,
     which can invalidate the kubectl CVE suppressions in
-    `.trivyignore.yaml` (currently scoped to `release-1.36`/Go-1.26.2,
+    `.trivyignore.yaml` (currently scoped to `release-1.36`/Go-1.26.4/x-net-0.49.0,
     `expired_at: 2026-08-12`) — re-review those entries after bumping.
 - **`.nvmrc`** is the source of truth for Node version, read via the
   shared `read_nvmrc` helper (`env.sh:122-124`, `tr -d '[:space:]'`) —

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -41,6 +41,36 @@ vulnerabilities:
       - usr/local/bin/kubectl
     statement: html/template <script> type-attr XSS; kubectl renders no HTML templates
     expired_at: 2026-08-12
+  - id: CVE-2026-25681
+    paths:
+      - usr/local/bin/kubectl
+    statement: golang.org/x/net/html XSS via crafted markup; kubectl renders no HTML from untrusted input
+    expired_at: 2026-08-12
+  - id: CVE-2026-27136
+    paths:
+      - usr/local/bin/kubectl
+    statement: golang.org/x/net/html parser XSS bypass; kubectl renders no HTML from untrusted input
+    expired_at: 2026-08-12
+  - id: CVE-2026-27145
+    paths:
+      - usr/local/bin/kubectl
+    statement: crypto/x509 DNS-name DoS; kubectl only verifies its configured API-server cert
+    expired_at: 2026-08-12
+  - id: CVE-2026-39821
+    paths:
+      - usr/local/bin/kubectl
+    statement: golang.org/x/net/idna Punycode label handling; kubeconfig-controlled hosts only, not attacker-controlled
+    expired_at: 2026-08-12
+  - id: CVE-2026-39822
+    paths:
+      - usr/local/bin/kubectl
+    statement: os.Root symlink-following bypass; kubectl uses no os.Root filesystem confinement
+    expired_at: 2026-08-12
+  - id: CVE-2026-42504
+    paths:
+      - usr/local/bin/kubectl
+    statement: mime header parsing DoS; kubectl parses no MIME headers from untrusted input
+    expired_at: 2026-08-12
 
 misconfigurations:
   # KSV-0109 false positive: flags `password:`/`secret:`-named keys in these ConfigMaps, but the

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -13,6 +13,11 @@ vulnerabilities:
       - usr/local/bin/kubectl
     statement: x/net/html parsing-bypass XSS; kubectl parses no untrusted HTML
     expired_at: 2026-08-12
+  - id: CVE-2026-33814
+    paths:
+      - usr/local/bin/kubectl
+    statement: x/net http2 SETTINGS-frame DoS needs a malicious server; kubectl talks only to in-cluster API
+    expired_at: 2026-08-12
   - id: CVE-2026-39821
     paths:
       - usr/local/bin/kubectl

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -41,36 +41,6 @@ vulnerabilities:
       - usr/local/bin/kubectl
     statement: html/template <script> type-attr XSS; kubectl renders no HTML templates
     expired_at: 2026-08-12
-  - id: CVE-2026-25681
-    paths:
-      - usr/local/bin/kubectl
-    statement: golang.org/x/net/html XSS via crafted markup; kubectl renders no HTML from untrusted input
-    expired_at: 2026-08-12
-  - id: CVE-2026-27136
-    paths:
-      - usr/local/bin/kubectl
-    statement: golang.org/x/net/html parser XSS bypass; kubectl renders no HTML from untrusted input
-    expired_at: 2026-08-12
-  - id: CVE-2026-27145
-    paths:
-      - usr/local/bin/kubectl
-    statement: crypto/x509 DNS-name DoS; kubectl only verifies its configured API-server cert
-    expired_at: 2026-08-12
-  - id: CVE-2026-39821
-    paths:
-      - usr/local/bin/kubectl
-    statement: golang.org/x/net/idna Punycode label handling; kubeconfig-controlled hosts only, not attacker-controlled
-    expired_at: 2026-08-12
-  - id: CVE-2026-39822
-    paths:
-      - usr/local/bin/kubectl
-    statement: os.Root symlink-following bypass; kubectl uses no os.Root filesystem confinement
-    expired_at: 2026-08-12
-  - id: CVE-2026-42504
-    paths:
-      - usr/local/bin/kubectl
-    statement: mime header parsing DoS; kubectl parses no MIME headers from untrusted input
-    expired_at: 2026-08-12
 
 misconfigurations:
   # KSV-0109 false positive: flags `password:`/`secret:`-named keys in these ConfigMaps, but the

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,45 +1,27 @@
 vulnerabilities:
-  # Go stdlib CVEs in kubectl (argocd image). Fixed in Go 1.26.3; k8s release-1.36 still builds on 1.26.2.
-  # Unreachable: kubectl only talks to the cluster API. Drop once a Go-1.26.3+ kubectl lands; expired_at forces re-review otherwise.
-  - id: CVE-2026-33811
+  # Go stdlib + x/net CVEs in kubectl (argocd image). kubectl v1.36.2 builds on Go 1.26.4 with
+  # x/net v0.49.0; these need Go 1.26.5 / x/net 0.55.0. Unreachable: kubectl only talks to the
+  # cluster API. Drop once a kubectl built on Go 1.26.5+ and x/net 0.55.0+ lands (likely v1.36.3);
+  # expired_at forces re-review otherwise.
+  - id: CVE-2026-25681
     paths:
       - usr/local/bin/kubectl
-    statement: LookupCNAME cgo-DNS DoS not exercised
+    statement: x/net/html XSS; kubectl parses no untrusted HTML
     expired_at: 2026-08-12
-  - id: CVE-2026-33814
+  - id: CVE-2026-27136
     paths:
       - usr/local/bin/kubectl
-    statement: HTTP/2 SETTINGS-frame DoS needs a malicious server; kubectl talks only to in-cluster API
+    statement: x/net/html parsing-bypass XSS; kubectl parses no untrusted HTML
     expired_at: 2026-08-12
-  - id: CVE-2026-39820
+  - id: CVE-2026-39821
     paths:
       - usr/local/bin/kubectl
-    statement: net/mail ParseAddress DoS not used by kubectl
+    statement: x/net/idna Punycode privilege escalation; kubectl resolves hosts from kubeconfig only
     expired_at: 2026-08-12
-  - id: CVE-2026-39836
+  - id: CVE-2026-39822
     paths:
       - usr/local/bin/kubectl
-    statement: net.Dial/LookupPort NUL-byte panic needs an attacker-controlled host; kubectl reads kubeconfig only
-    expired_at: 2026-08-12
-  - id: CVE-2026-42499
-    paths:
-      - usr/local/bin/kubectl
-    statement: net/mail consumePhrase DoS not exercised by kubectl
-    expired_at: 2026-08-12
-  - id: CVE-2026-39823
-    paths:
-      - usr/local/bin/kubectl
-    statement: html/template <meta> content URL XSS; kubectl renders no HTML templates
-    expired_at: 2026-08-12
-  - id: CVE-2026-39825
-    paths:
-      - usr/local/bin/kubectl
-    statement: net/http/httputil ReverseProxy query-param forwarding needs an internet-facing proxy; kubectl proxy binds localhost only
-    expired_at: 2026-08-12
-  - id: CVE-2026-39826
-    paths:
-      - usr/local/bin/kubectl
-    statement: html/template <script> type-attr XSS; kubectl renders no HTML templates
+    statement: os.Root symlink traversal; kubectl does not open untrusted directory trees
     expired_at: 2026-08-12
 
 misconfigurations:

--- a/packages/argocd/Dockerfile
+++ b/packages/argocd/Dockerfile
@@ -23,8 +23,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && rm -rf awscliv2.zip aws
 
 # renovate: datasource=github-releases packageName=kubernetes/kubernetes
-ARG KUBECTL_VERSION=v1.36.1
-ARG KUBECTL_SHA256=629d3f410e09bf49b64ae7079f7f0bda1191efed311f7d37fdbab0ad5b0ec2b7
+ARG KUBECTL_VERSION=v1.36.2
+ARG KUBECTL_SHA256=1e9045ec32bea85da43de85f0065358529ea7c7a152eca78154fba5b58c27d82
 RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
     && echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c - \
     && chmod +x kubectl \

--- a/packages/argocd/Dockerfile
+++ b/packages/argocd/Dockerfile
@@ -6,12 +6,12 @@ RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
     && apt-get update && apt-get install -y --no-install-recommends \
     bash=5.2.15-2+b13 \
     curl=7.88.1-10+deb12u14 \
-    jq=1.6-2.1+deb12u1 \
+    jq=1.6-2.1+deb12u2 \
     git=1:2.39.5-0+deb12u3 \
     unzip=6.0-28 \
     ca-certificates=20230311+deb12u1 \
     libgnutls30=3.7.9-2+deb12u7 \
-    apache2-utils=2.4.67-1~deb12u2 \
+    apache2-utils=2.4.67-1~deb12u3 \
     && rm -rf /var/lib/apt/lists/* \
     && corepack enable
 


### PR DESCRIPTION
# Title

fix(deps): bump jq/apache2-utils in argocd Dockerfile for HIGH CVEs

## Description

Bump two apt pins in `packages/argocd/Dockerfile` to their fixed
point-releases in Debian bookworm-security:

- `jq` `1.6-2.1+deb12u1` → `1.6-2.1+deb12u2` — fixes trivy HIGH
  `CVE-2026-32316` (DoS / potential ACE) and `CVE-2026-40164`
  (hash-collision DoS) on both `jq` and its `libjq1` transitive.
- `apache2-utils` `2.4.67-1~deb12u2` → `2.4.67-1~deb12u3` — fixes
  trivy HIGH `CVE-2026-49975` (HTTP/2 compression-bomb / Slowloris DoS
  in httpd).

Also unblocks the `build-publish-images (argocd-sst-plugin)` CI job.
After debian-security shipped the newer `libjq1`, apt now resolves
`libjq1=deb12u2` unconditionally, so the old pin `jq=deb12u1` fails
with `jq : Depends: libjq1 (= 1.6-2.1+deb12u1) but 1.6-2.1+deb12u2 is
to be installed`. Matching `jq` to `deb12u2` restores the dependency
lock.

**Update (follow-up commits on this PR):** kubectl is now bumped
`v1.36.1 → v1.36.2` (with the mandatory `KUBECTL_SHA256` update, verified
against `dl.k8s.io/release/v1.36.2/.../kubectl.sha256` and a local
`sha256sum` of the binary). v1.36.2 is built on Go 1.26.4 (v1.36.1 was
1.26.2), which clears `CVE-2026-27145`/`CVE-2026-42504` **and** the 8
previously suppressed Go-1.26.3-fixed CVEs — those `.trivyignore.yaml`
entries are removed.

**Remaining suppressions (5, all scoped to `usr/local/bin/kubectl`,
`expired_at: 2026-08-12`).** No released kubectl fixes these — v1.36.2 is
the newest 1.36 tag and still vendors `x/net v0.49.0` / Go 1.26.4 stdlib,
so per the "exhausted all options" fallback they are suppressed with an
expiry instead of left red. **Drop all 5 when a kubectl built on
Go 1.26.5+ and x/net 0.55.0+ ships (expected v1.36.3, ~mid-Aug 2026
patch cycle)**; Renovate's kubectl customManager will surface the
version bump, the SHA edit stays manual (`Dockerfile:26-27`).

| CVE | Origin | Fixed in |
| --- | --- | --- |
| `CVE-2026-25681` | `golang.org/x/net/html` | x/net v0.55.0 |
| `CVE-2026-27136` | `golang.org/x/net/html` | x/net v0.55.0 |
| `CVE-2026-33814` | `x/net http2` (previously misfiled under the Go-stdlib batch) | x/net v0.53.0 |
| `CVE-2026-39821` | `golang.org/x/net/idna` | x/net v0.55.0 |
| `CVE-2026-39822` | `os.Root` | Go 1.25.12 / 1.26.5 |

Side effect: unblocks the two open renovate PRs whose CI was red on
this same Dockerfile — #80 (`renovate/all-minor-patch`) and #81
(`renovate/all-digest`); the same fixes were pushed to those branches
directly. #90 carries the canonical copies for main.

## Checklist

- [ ] _If you have added a new dependency to this project_, make sure to add it to the dependencies part of the README.
- [ ] _If you have interacted with [`SST Secrets`](https://sst.dev/docs/component/secret/)_, make sure to deploy it and that it doesn't just exist in the intermediary state of `sst secret list`. Run `pnpm sst shell -- node ./scripts/lib/sst-resources.js` to see the deployed resources created by SST.
- [ ] _If you have created new templated compute variables_, make sure to add it to the [`/scripts/cluster/deploy.sh`](https://github.com/Pandoks/pandoks.com/blob/main/scripts/cluster/deploy.sh) script's `cmd_deploy_compute_vars` function.
- [ ] _If you have created a new kubernetes node and control plane_, make sure to add the endpoint to the [`prom-grafana.yaml`](https://github.com/Pandoks/pandoks.com/blob/main/k3s/overlays/cluster/prom-etcd-config.yaml) overlays.
- [ ] _If you create a new app deployment_, make sure to add Prometheus metrics to export for observability.