### PR TITLE
fix(deps): floor undici 7.x, form-data, tar, tmp overrides for open CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,13 @@ settings:
 overrides:
   '@xmldom/xmldom': ^0.9.10
   picomatch: ^4.0.4
-  tar: ^7.5.13
+  tar: ^7.5.16
   cookie: ~1.1.0
-  tmp: ^0.2.5
+  tmp: ^0.2.6
   '@electron/node-gyp': ^10.2.0-electron.2
+  form-data: ^4.0.6
+  jsdom>undici: ^7.28.0
+  '@electron/get>undici': ^7.28.0
 
 importers:
 
@@ -2761,8 +2764,8 @@ packages:
   fontverter@2.0.0:
     resolution: {integrity: sha512-DFVX5hvXuhi1Jven1tbpebYTCT9XYnvx6/Z+HFUPb7ZRMCW+pj2clU9VMhoTPgWKPhAs7JJDSk3CW1jNUvKCZQ==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-extra@10.1.0:
@@ -2934,6 +2937,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -4459,8 +4466,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.20:
+    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
     engines: {node: '>=18'}
 
   temp@0.9.4:
@@ -4543,8 +4550,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tn1150@0.1.0:
@@ -4639,8 +4646,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   undici@8.3.0:
@@ -5611,7 +5618,7 @@ snapshots:
       semver: 7.8.5
       sumchecker: 3.0.1
     optionalDependencies:
-      undici: 7.25.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5625,7 +5632,7 @@ snapshots:
       nopt: 6.0.0
       proc-log: 2.0.1
       semver: 7.8.5
-      tar: 7.5.15
+      tar: 7.5.20
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -5690,7 +5697,7 @@ snapshots:
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
       semver: 7.8.5
-      tar: 7.5.15
+      tar: 7.5.20
       yargs: 17.7.2
     transitivePeerDependencies:
       - bluebird
@@ -6929,7 +6936,7 @@ snapshots:
   axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -7061,7 +7068,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 9.0.1
-      tar: 7.5.15
+      tar: 7.5.20
       unique-filename: 2.0.1
     transitivePeerDependencies:
       - bluebird
@@ -7706,7 +7713,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.2.5
+      tmp: 0.2.7
 
   extract-zip@2.0.1:
     dependencies:
@@ -7811,12 +7818,12 @@ snapshots:
       wawoff2: 2.0.1
       woff2sfnt-sfnt2woff: 1.0.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs-extra@10.1.0:
@@ -8033,6 +8040,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   he@1.2.0: {}
 
   highlight.js@11.11.1: {}
@@ -8221,7 +8232,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9488,7 +9499,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.15:
+  tar@7.5.20:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -9541,10 +9552,10 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
     optional: true
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   tn1150@0.1.0:
     dependencies:
@@ -9629,7 +9640,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   undici@8.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,10 @@ allowBuilds:
 overrides:
   '@xmldom/xmldom': ^0.9.10 # @electron-forge/cli → plist@^0.8.x
   picomatch: ^4.0.4 # @electron-forge/cli + vite-plugin-static-copy → anymatch@^2.x
-  tar: ^7.5.13 # @electron-forge/cli → @electron/node-gyp@^6.x
+  tar: ^7.5.16 # @electron-forge/cli → @electron/node-gyp@^6.x; floor for GHSA-vmf3-w455-68vh
   cookie: ~1.1.0 # @sveltejs/kit@^0.6.x
-  tmp: ^0.2.5 # @electron-forge/cli → external-editor@^0.0.33
+  tmp: ^0.2.6 # @electron-forge/cli → external-editor@^0.0.33; floor for GHSA-ph9p-34f9-6g65
   '@electron/node-gyp': ^10.2.0-electron.2 # @electron-forge/cli → @electron/rebuild@3.7
+  form-data: ^4.0.6 # twilio → axios; floor for GHSA-hmw2-7cc7-3qxx
+  jsdom>undici: ^7.28.0 # vitest → jsdom; floor for GHSA-vmh5-mc38-953g + 6 more undici 7.x CVEs
+  '@electron/get>undici': ^7.28.0 # @electron-forge/cli → @electron/get; same undici 7.x CVE floor


### PR DESCRIPTION
# Title

fix(deps): floor undici 7.x, form-data, tar, tmp overrides for open CVEs

## Description

Fixes every npm advisory currently open against the lockfile that is **not** already covered by an open Renovate/Dependabot PR. All changes are `pnpm-workspace.yaml` overrides (the repo's established CVE-override location) plus the lockfile regen — no dependency specs changed.

New/raised override floors:

- `jsdom>undici: ^7.28.0` (new) — jsdom pins undici `^7.25.0`; 7 advisories affect `>=7.0.0 <7.28.0` (GHSA-vmh5-mc38-953g WebSocket DoS, SOCKS5 TLS-validation bypass, SOCKS5 cross-origin routing, response-queue poisoning, Set-Cookie SameSite downgrade, Set-Cookie header injection, shared-cache whitespace bypass). Resolves 7.25.0 → 7.28.0.
- `@electron/get>undici: ^7.28.0` (new) — same 7.x CVE floor for the electron-forge chain's optional undici. Scoped per-parent (like the jsdom one) so the direct `undici@8.x` dep in `apps/functions` is untouched.
- `form-data: ^4.0.6` (new) — GHSA-hmw2-7cc7-3qxx CRLF injection (`>=4.0.0 <4.0.6`), reached via `twilio → axios`. Resolves 4.0.5 → 4.0.6.
- `tar: ^7.5.13 → ^7.5.16` — GHSA-vmf3-w455-68vh tar-parser file smuggling (`<=7.5.15`). Resolves 7.5.15 → 7.5.20.
- `tmp: ^0.2.5 → ^0.2.6` — GHSA-ph9p-34f9-6g65 path traversal (`<0.2.6`). Resolves 0.2.5 → 0.2.7.

Intentionally **not** touched here (already fixed by open PRs — merge those for these alerts):

- `undici@8.3.0` → 8.5.0 fixes all open 8.x advisories: #86 / #87
- `vite@8.0.14` → 8.0.16 fixes CVE-2026-53571 + launch-editor CVE-2026-53632: #83 / #84
- pnpm 11.8.0 [security]: #88

Verified with the npm bulk advisory endpoint: after this change the only flagged resolutions left in `pnpm-lock.yaml` are the undici 8.3.0/vite 8.0.14 ones deferred to the PRs above. `pnpm -r --if-present check` and `apps/web` unit tests (43/43) pass; `govulncheck` on the valkey reconciler is clean.

Note: the "Cloudflare Pages" commit status on this PR will stay red until #95 (restores the root `.node-version` pin) merges — this PR touches `pnpm-lock.yaml`/`pnpm-workspace.yaml`, which triggers a Pages preview build that currently fails on every branch for that unrelated reason.

## Checklist

- [ ] _If you have added a new dependency to this project_, make sure to add it to the dependencies part of the README. — N/A, override floors on existing transitive deps only.
- [ ] _If you have interacted with [`SST Secrets`](https://sst.dev/docs/component/secret/)_ — N/A.
- [ ] _If you have created new templated compute variables_ — N/A.
- [ ] _If you have created a new kubernetes node and control plane_ — N/A.
- [ ] _If you create a new app deployment_ — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kkt41fTQ9r4zAPxmn3FtBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kkt41fTQ9r4zAPxmn3FtBZ)_